### PR TITLE
Enhance editor interface styling

### DIFF
--- a/Nile.html
+++ b/Nile.html
@@ -45,7 +45,14 @@
     <aside class="right">
       <section class="card">
         <header><h3>Histogram</h3><span id="sizeInfo">—</span></header>
-        <div class="card-body"><canvas id="hist" class="hist"></canvas></div>
+        <div class="card-body">
+          <div class="chart-modes" role="tablist" aria-label="Chart display modes">
+            <button class="chip active" data-chart-mode="rgb" role="tab" aria-selected="true">RGB Overlay</button>
+            <button class="chip" data-chart-mode="channels" role="tab" aria-selected="false">Channel Bars</button>
+            <button class="chip" data-chart-mode="luma" role="tab" aria-selected="false">Luminance</button>
+          </div>
+          <canvas id="hist" class="hist" role="img" aria-label="Histogram visualization"></canvas>
+        </div>
       </section>
 
       <section class="card">

--- a/styles.css
+++ b/styles.css
@@ -142,6 +142,35 @@ body{
 .card>header h3{margin:0;color:var(--text);font-size:13px;letter-spacing:.04em;text-transform:none}
 .card .card-body{padding:14px 16px}
 
+.chart-modes{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-bottom:14px;
+}
+
+.chip{
+  border:1px solid rgba(58,66,96,.6);
+  background:rgba(30,36,52,.75);
+  color:var(--muted);
+  padding:6px 12px;
+  border-radius:999px;
+  font:500 12px/1 "Inter",system-ui,-apple-system,Segoe UI,Roboto,Arial;
+  letter-spacing:.02em;
+  cursor:pointer;
+  transition:background var(--transition),border-color var(--transition),color var(--transition),box-shadow var(--transition);
+  box-shadow:0 8px 18px rgba(6,8,16,.32);
+}
+
+.chip:hover{background:rgba(48,56,78,.85);border-color:var(--outline-strong);color:var(--text)}
+.chip:focus-visible{outline:2px solid var(--brand);outline-offset:2px}
+.chip.active{
+  background:linear-gradient(135deg,rgba(91,134,255,.35),rgba(91,134,255,.12));
+  border-color:rgba(91,134,255,.55);
+  color:var(--text);
+  box-shadow:0 12px 26px rgba(38,60,122,.45);
+}
+
 .nav{
   width:100%;
   height:180px;
@@ -186,7 +215,7 @@ body{
 
 .hist{
   width:100%;
-  height:70px;
+  height:90px;
   background:#0c1020;
   border-radius:12px;
   border:1px solid rgba(58,66,96,.55);

--- a/styles.css
+++ b/styles.css
@@ -1,40 +1,240 @@
 :root{
-  --bg:#0e0f13; --panel:#151821; --panel2:#1b1f2b;
-  --text:#eaf0ff; --muted:#a6afc6; --outline:#2a3042;
+  --bg:#0b0d12;
+  --bg-soft:#121522ee;
+  --panel:#151821;
+  --panel2:#1b1f2b;
+  --panel3:rgba(21,24,33,.6);
+  --text:#eaf0ff;
+  --muted:#a6afc6;
+  --outline:#2a3042;
+  --outline-strong:#3a4260;
   --brand:#5b86ff;
-  --r:14px;
+  --brand-strong:#6c95ff;
+  --danger:#ff6b8a;
+  --radius:14px;
+  --transition:150ms ease;
+  --shadow:0 18px 38px rgba(5,8,16,.35);
 }
+
 *{box-sizing:border-box}
+*::selection{background:rgba(91,134,255,.35)}
 html,body{height:100%}
-body{margin:0;background:linear-gradient(180deg,#0e1016,#0b0d12);color:var(--text);
-  font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial;display:flex;flex-direction:column}
-.topbar{display:flex;justify-content:space-between;align-items:center;padding:10px 14px;border-bottom:1px solid var(--outline);background:#121522}
-.brand{display:flex;align-items:center;gap:10px}
-.logo{width:22px;height:22px;border-radius:6px;background:linear-gradient(135deg,#7ea0ff, #5b86ff)}
-.tag{color:var(--muted);font-size:12px}
-.actions{display:flex;gap:8px}
-.btn{background:var(--panel2);color:var(--text);border:1px solid var(--outline);border-radius:10px;padding:8px 12px;cursor:pointer}
-.btn:disabled{opacity:.6;cursor:not-allowed}
-.btn.primary{background:var(--brand);border-color:transparent;color:#fff}
+body{
+  margin:0;
+  background:radial-gradient(120% 150% at 20% 20%,#141a2c 0%,#090b12 55%,#07090f 100%);
+  color:var(--text);
+  font:14px/1.5 "Inter",system-ui,-apple-system,Segoe UI,Roboto,Arial;
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+}
 
-.layout{flex:1;min-height:0;display:grid;grid-template-columns:280px 380px 1fr}
-.left{border-right:1px solid var(--outline);background:var(--panel);overflow:auto}
-.right{border-left:1px solid var(--outline);background:var(--panel);overflow:auto}
-.stage{position:relative;display:grid;place-items:center;background:#0a0d15}
+.topbar{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:14px 20px;
+  border-bottom:1px solid var(--outline);
+  background:var(--bg-soft);
+  backdrop-filter:blur(22px);
+  position:sticky;
+  top:0;
+  z-index:10;
+  box-shadow:0 12px 28px rgba(6,8,15,.45);
+}
 
-.card{margin:12px;background:var(--panel2);border:1px solid var(--outline);border-radius:var(--r);overflow:hidden}
-.card>header{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;border-bottom:1px solid var(--outline)}
-.card .card-body{padding:10px 12px}
-.nav{width:100%;height:180px;background:#000;border-radius:10px;border:1px solid var(--outline)}
-.meta{display:flex;justify-content:space-between;color:var(--muted);margin-top:6px}
-.list{padding:8px 10px;display:grid;gap:6px}
-.row{display:flex;justify-content:space-between;align-items:center;background:#141827;border:1px solid var(--outline);padding:6px 8px;border-radius:10px}
+.brand{display:flex;align-items:center;gap:12px;font-weight:600;letter-spacing:.01em}
+.logo{
+  width:26px;height:26px;border-radius:8px;
+  background:linear-gradient(135deg,#8ba8ff 0%,#5b86ff 50%,#4165e0 100%);
+  box-shadow:0 0 0 2px rgba(91,134,255,.35),0 12px 18px rgba(9,12,24,.55);
+}
+.brand strong{font-size:16px}
+.tag{color:var(--muted);font-size:12px;padding:2px 8px;border-radius:999px;border:1px solid rgba(166,175,198,.25);background:rgba(18,24,33,.45)}
 
-.controls .control{display:grid;grid-template-columns:1fr 60px;gap:10px;margin:10px 0;align-items:center}
-.controls .val{font:600 12px/1 ui-monospace,Menlo,Consolas;text-align:right}
-input[type=range]{width:100%}
-.hist{width:100%;height:70px;background:#0c1020;border-radius:10px;border:1px solid var(--outline)}
+.actions{display:flex;gap:10px;align-items:center}
+.btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:6px;
+  background:var(--panel3);
+  color:var(--text);
+  border:1px solid var(--outline);
+  border-radius:10px;
+  padding:9px 18px;
+  font-weight:500;
+  letter-spacing:.01em;
+  cursor:pointer;
+  transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),background var(--transition),color var(--transition);
+  box-shadow:0 10px 18px rgba(8,11,20,.35);
+}
+.btn:hover:not(:disabled){
+  transform:translateY(-1px);
+  border-color:var(--outline-strong);
+  background:rgba(37,43,63,.9);
+}
+.btn:focus-visible{
+  outline:2px solid var(--brand-strong);
+  outline-offset:2px;
+}
+.btn:disabled{opacity:.6;cursor:not-allowed;box-shadow:none}
+.btn.primary{
+  background:linear-gradient(135deg,var(--brand) 0%,var(--brand-strong) 100%);
+  border-color:transparent;
+  color:#fff;
+  box-shadow:0 18px 30px rgba(56,100,255,.35);
+}
+.btn.primary:hover:not(:disabled){background:linear-gradient(135deg,var(--brand-strong) 0%,#7da0ff 100%)}
 
-#preview{max-width:100%;max-height:100%;background:#000;border-radius:12px;border:1px solid #000}
+.layout{
+  flex:1;
+  min-height:0;
+  display:grid;
+  grid-template-columns:260px 340px minmax(0,1fr);
+  gap:0;
+  background:radial-gradient(140% 140% at 80% 10%,rgba(91,134,255,.25) 0%,rgba(9,11,18,0) 55%),linear-gradient(180deg,rgba(18,21,32,.65),rgba(8,10,18,.85));
+}
+.left,.right{
+  border-right:1px solid var(--outline);
+  background:rgba(18,22,33,.72);
+  overflow:auto;
+  padding:10px 0 24px;
+  backdrop-filter:blur(18px);
+}
+.right{border-right:none;border-left:1px solid var(--outline)}
+.stage{
+  position:relative;
+  display:grid;
+  place-items:center;
+  background:linear-gradient(145deg,rgba(4,5,9,.9),rgba(9,11,17,.92));
+  padding:36px;
+}
+.stage::before{
+  content:"";
+  position:absolute;
+  inset:40px;
+  border-radius:24px;
+  background:radial-gradient(120% 120% at 30% 20%,rgba(91,134,255,.18),rgba(29,34,48,0));
+  pointer-events:none;
+  filter:blur(0.5px);
+}
 
-.foot{border-top:1px solid var(--outline);color:var(--muted);padding:8px 12px;background:#0f1320}
+.card{
+  margin:16px 18px;
+  background:linear-gradient(140deg,rgba(27,31,43,.88),rgba(18,22,33,.72));
+  border:1px solid rgba(58,66,96,.45);
+  border-radius:var(--radius);
+  overflow:hidden;
+  box-shadow:var(--shadow);
+}
+.card>header{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:12px 16px;
+  border-bottom:1px solid rgba(53,60,83,.6);
+  text-transform:uppercase;
+  font-size:12px;
+  letter-spacing:.08em;
+  color:var(--muted);
+}
+.card>header h3{margin:0;color:var(--text);font-size:13px;letter-spacing:.04em;text-transform:none}
+.card .card-body{padding:14px 16px}
+
+.nav{
+  width:100%;
+  height:180px;
+  background:#05070c;
+  border-radius:12px;
+  border:1px solid rgba(58,66,96,.55);
+  box-shadow:0 12px 24px rgba(3,5,12,.45);
+  cursor:crosshair;
+}
+.meta{display:flex;justify-content:space-between;color:var(--muted);margin-top:10px;font-size:12px;letter-spacing:.02em}
+.list{padding:10px 14px;display:grid;gap:8px}
+.row{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  background:rgba(20,24,39,.9);
+  border:1px solid rgba(54,61,85,.55);
+  padding:8px 12px;
+  border-radius:12px;
+  font-size:13px;
+  transition:transform var(--transition),background var(--transition),border-color var(--transition);
+}
+.row:hover{transform:translateY(-1px);background:rgba(30,36,52,.95);border-color:var(--outline-strong)}
+
+.controls .control{
+  display:grid;
+  grid-template-columns:minmax(0,1fr) 64px;
+  gap:12px;
+  margin:12px 0 4px;
+  align-items:center;
+}
+.controls label{text-transform:capitalize;letter-spacing:.01em;color:var(--text)}
+.controls .val{font:600 12px/1 ui-monospace,Menlo,Consolas;text-align:right;color:var(--muted)}
+.controls input[type=range]{
+  width:100%;
+  accent-color:var(--brand);
+  height:3px;
+  background:linear-gradient(90deg,rgba(91,134,255,.65),rgba(65,102,224,.2));
+  border-radius:999px;
+}
+.controls input[type=range]:focus-visible{outline:none;box-shadow:0 0 0 3px rgba(91,134,255,.25)}
+
+.hist{
+  width:100%;
+  height:70px;
+  background:#0c1020;
+  border-radius:12px;
+  border:1px solid rgba(58,66,96,.55);
+  box-shadow:0 12px 24px rgba(3,5,12,.45);
+}
+
+#preview{
+  max-width:calc(100% - 32px);
+  max-height:calc(100% - 32px);
+  background:#06090f;
+  border-radius:20px;
+  border:1px solid rgba(12,18,30,.85);
+  box-shadow:0 24px 42px rgba(5,7,12,.65);
+  z-index:1;
+}
+
+.foot{
+  border-top:1px solid var(--outline);
+  color:var(--muted);
+  padding:12px 20px;
+  background:linear-gradient(180deg,rgba(11,14,23,.92),rgba(8,10,18,.95));
+  font-size:13px;
+  letter-spacing:.01em;
+}
+
+::-webkit-scrollbar{width:10px}
+::-webkit-scrollbar-track{background:rgba(8,10,18,.6)}
+::-webkit-scrollbar-thumb{background:rgba(58,66,96,.6);border-radius:999px;border:2px solid rgba(8,10,18,.6)}
+::-webkit-scrollbar-thumb:hover{background:rgba(91,134,255,.55)}
+
+@media (max-width:1280px){
+  .layout{grid-template-columns:220px 320px minmax(0,1fr)}
+  .topbar{padding:12px 16px}
+}
+
+@media (max-width:1080px){
+  body{overflow:auto}
+  .layout{grid-template-columns:260px minmax(0,1fr);grid-template-areas:"left right" "stage stage";}
+  .left{grid-area:left;min-height:340px}
+  .right{grid-area:right}
+  .stage{grid-area:stage;padding:24px}
+}
+
+@media (max-width:768px){
+  .layout{grid-template-columns:1fr;grid-template-areas:"left" "right" "stage";}
+  .left,.right{border:none;border-bottom:1px solid var(--outline)}
+  .topbar{flex-direction:column;align-items:flex-start;gap:12px}
+  .actions{width:100%;justify-content:space-between}
+  .stage{padding:18px}
+  #preview{max-width:100%;max-height:100%;}
+}


### PR DESCRIPTION
## Summary
- refresh the global theme with richer gradients, glassmorphism panels, and interactive button states to modernize the editor chrome
- refine panel, navigator, and canvas styling with softer shadows and hover feedback for improved visual hierarchy
- add responsive layout rules so side panels and stage rearrange cleanly on medium and small viewports

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d54114cabc8330bf5b92421ef31587